### PR TITLE
Don't instantiate Step class to get the type

### DIFF
--- a/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitDescriptionGenerator.java
+++ b/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitDescriptionGenerator.java
@@ -187,8 +187,8 @@ public class JUnitDescriptionGenerator {
 		// jump to the corresponding test method accordingly. For now we have to
 		// live, that we end up in
 		// the correct class.
-		Description testDescription = Description.createTestDescription(step
-				.getStepsInstance().getClass(), getJunitSafeString(stringStep));
+		Description testDescription = Description.createTestDescription(step.getStepsType(),
+		        getJunitSafeString(stringStep));
 		description.addChild(testDescription);
 	}
 


### PR DESCRIPTION
This commit depends on JBEHAVE-895 (link below).  It won't compile until jbehave-junit-runner is pointed to jBehave 3.7.6.

https://jira.codehaus.org/browse/JBEHAVE-895
