### PR TITLE
chore(Settings): Define whitespace policy through EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = tab
+
+[*.xml]
+indent_style = tab


### PR DESCRIPTION
The project does not currently define a whitespace policy and
therefore had to reject a pull request. Instead of defining the
policy in a contribution section, we can benefit from the
EditorConfig project and the various IDE integrations
by defining a .editorconfig file.
