### PR TITLE
Fix asymmetry of JUnit notifier invocations on failed steps.

### DIFF
--- a/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitScenarioReporter.java
+++ b/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitScenarioReporter.java
@@ -224,6 +224,7 @@ public class JUnitScenarioReporter implements StoryReporter {
 		logger.info("Step Failed: {} (cause: {})", step, e.getMessage());
 		if (!givenStoryContext) {
 			notifier.fireTestFailure(new Failure(currentStep, e));
+			notifier.fireTestFinished(currentStep);
 			failedSteps.add(currentStep);
 			prepareNextStep();
 		}
@@ -253,6 +254,7 @@ public class JUnitScenarioReporter implements StoryReporter {
 				notifier.fireTestStarted(currentStep);
 				notifier.fireTestFailure(new Failure(currentStep,
 						new RuntimeException("Step is pending!")));
+				notifier.fireTestFinished(currentStep);
 			} else {
 				notifier.fireTestIgnored(currentStep);
 			}

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitScenarioReporterTest.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitScenarioReporterTest.java
@@ -96,6 +96,7 @@ public class JUnitScenarioReporterTest {
 		verifyScenarioStarted();
 		verify(notifier).fireTestStarted(child1);
 		verify(notifier).fireTestFailure(Matchers.<Failure> anyObject());
+		verify(notifier).fireTestFinished(child1);
 	}
 
 	@Test
@@ -325,6 +326,7 @@ public class JUnitScenarioReporterTest {
 		verifyScenarioStarted();
 		verify(notifier).fireTestStarted(child);
 		verify(notifier).fireTestFailure(Mockito.<Failure> anyObject());
+		verify(notifier).fireTestFinished(child);
 	}
 
 	@Test


### PR DESCRIPTION
The JUnit Notifier.fireTestFinished will also be called when a step fails.
This symmetry allows gradle to detect failed steps.
Without the invocation gradle ignores test failures and marks the build
as successful.

Peter Niederwiesers answer: http://forums.gradle.org/gradle/topics/with_custom_junit_runner_failures_are_ignored
