### PR TITLE
Configure build for coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ jdk:
   - oraclejdk7
   - oraclejdk8
   - openjdk7
+
+after_success:
+  - mvn jacoco:report coveralls:report
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 JBehave JUnit Integration
 =========================
 [![Build Status](https://travis-ci.org/codecentric/jbehave-junit-runner.png?branch=master)](https://travis-ci.org/codecentric/jbehave-junit-runner)
+[![Coverage Status](https://coveralls.io/repos/codecentric/jbehave-junit-runner/badge.svg)](https://coveralls.io/r/codecentric/jbehave-junit-runner)
 
 This little project is designed to make JBehave
 stories & scenarios show up in the JUnit view

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,50 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>travis</id>
+			<activation>
+				<property>
+					<name>env.TRAVIS</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>0.7.3.201502191951</version>
+						<executions>
+							<!-- Prepares the property pointing to the JaCoCo
+							runtime agent which is passed as VM argument when Maven the Surefire plugin
+							is executed. -->
+							<execution>
+								<id>pre-unit-test</id>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+
+							<!-- Ensures that the code coverage report for
+							unit tests is created after unit tests have been run. -->
+							<execution>
+								<id>post-unit-test</id>
+								<phase>test</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eluder.coveralls</groupId>
+						<artifactId>coveralls-maven-plugin</artifactId>
+						<version>3.0.1</version>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 


### PR DESCRIPTION
Coveralls has been activated for this repository (https://coveralls.io/r/codecentric/jbehave-junit-runner).

Now the build has to be configured so that coveralls receives coverage data from the maven build.
