### PR TITLE
Upgarding to JBehave 4.0.5, JUnit 4.12, Mockito 1.10.19. Adding support for @BeforeStory/@AfterStory and @BeforeScenario/@AfterScenario.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
 	<properties>
 		<jdk.version>1.7</jdk.version>
-		<jbehave.version>4.0.3</jbehave.version>
+		<jbehave.version>4.0.5</jbehave.version>
 		<junit.version>4.12</junit.version>
 		<mockito.version>1.10.19</mockito.version>
 		<keystore.password>dev_password</keystore.password>

--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
 
 	<properties>
 		<jdk.version>1.7</jdk.version>
-		<jbehave.version>3.9</jbehave.version>
-		<junit.version>4.11</junit.version>
-		<mockito.version>1.9.0</mockito.version>
+		<jbehave.version>4.0.3</jbehave.version>
+		<junit.version>4.12</junit.version>
+		<mockito.version>1.10.19</mockito.version>
 		<keystore.password>dev_password</keystore.password>
 		<gpg.passphrase>dev</gpg.passphrase>
 		<passphrase>${gpg.passphrase}</passphrase>

--- a/src/main/java/de/codecentric/jbehave/junit/monitoring/DescriptionTextUniquefier.java
+++ b/src/main/java/de/codecentric/jbehave/junit/monitoring/DescriptionTextUniquefier.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 public class DescriptionTextUniquefier {
 
-	Set<String> strings = new HashSet<String>();
+	Set<String> strings = new HashSet<>();
 
 	public String getUniqueDescription(String junitSafeString) {
 		while (strings.contains(junitSafeString)) {

--- a/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitDescriptionGenerator.java
+++ b/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitDescriptionGenerator.java
@@ -116,8 +116,7 @@ public class JUnitDescriptionGenerator {
 	}
 
 	public String getJunitSafeString(String string) {
-		return uniq.getUniqueDescription(replaceLinebreaks(string)
-				.replaceAll("[\\(\\)]", "|"));
+		return uniq.getUniqueDescription(JUnitStringDecorator.getJunitSafeString(string));
 	}
 
 	public int getTestCases() {
@@ -269,11 +268,6 @@ public class JUnitDescriptionGenerator {
 			return stringStep.substring(0, stringStep.indexOf('\n'));
 		}
 		return stringStep;
-	}
-
-	private String replaceLinebreaks(String string) {
-		return string.replaceAll("\r", "\n")
-				.replaceAll("\n{2,}", "\n").replaceAll("\n", ", ");
 	}
 
 	private Description createDescriptionForStory(Story story) {

--- a/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitReportingRunner.java
+++ b/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitReportingRunner.java
@@ -10,7 +10,7 @@ import org.jbehave.core.ConfigurableEmbedder;
 import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.embedder.Embedder;
 import org.jbehave.core.embedder.EmbedderControls;
-import org.jbehave.core.embedder.StoryRunner;
+import org.jbehave.core.embedder.PerformableTree;
 import org.jbehave.core.io.StoryPathResolver;
 import org.jbehave.core.junit.JUnitStories;
 import org.jbehave.core.junit.JUnitStory;
@@ -81,9 +81,9 @@ public class JUnitReportingRunner extends BlockJUnit4ClassRunner {
 				// tell the reporter how to handle pending steps
 				junitReporter.usePendingStepStrategy(configuration
 						.pendingStepStrategy());
-			
+
 				addToStoryReporterFormats(junitReporter);
-			
+
 				try {
 					configuredEmbedder.runStoriesAsPaths(storyPaths);
 				} catch (Throwable e) {
@@ -94,7 +94,7 @@ public class JUnitReportingRunner extends BlockJUnit4ClassRunner {
 			}
 		};
 	}
-	
+
 	public static EmbedderControls recommandedControls(Embedder embedder) {
 		return recommendedControls(embedder);
 	}
@@ -191,11 +191,10 @@ public class JUnitReportingRunner extends BlockJUnit4ClassRunner {
 	private List<Description> buildDescriptionFromStories() {
 		JUnitDescriptionGenerator descriptionGenerator = new JUnitDescriptionGenerator(
 				candidateSteps, configuration);
-		StoryRunner storyRunner = new StoryRunner();
-		List<Description> storyDescriptions = new ArrayList<Description>();
+		List<Description> storyDescriptions = new ArrayList<>();
 
 		addSuite(storyDescriptions, "BeforeStories");
-		addStories(storyDescriptions, storyRunner, descriptionGenerator);
+		addStories(storyDescriptions, descriptionGenerator);
 		addSuite(storyDescriptions, "AfterStories");
 
 		numberOfTestCases += descriptionGenerator.getTestCases();
@@ -204,9 +203,10 @@ public class JUnitReportingRunner extends BlockJUnit4ClassRunner {
 	}
 
 	private void addStories(List<Description> storyDescriptions,
-			StoryRunner storyRunner, JUnitDescriptionGenerator gen) {
+	        JUnitDescriptionGenerator gen) {
+	    PerformableTree performableTree = new PerformableTree();
 		for (String storyPath : storyPaths) {
-			Story parseStory = storyRunner
+			Story parseStory = performableTree
 					.storyOfPath(configuration, storyPath);
 			Description descr = gen.createDescriptionFrom(parseStory);
 			storyDescriptions.add(descr);

--- a/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitReportingRunner.java
+++ b/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitReportingRunner.java
@@ -144,17 +144,20 @@ public class JUnitReportingRunner extends BlockJUnit4ClassRunner {
 				(JUnitStories) configurableEmbedder, (Object[]) null));
 	}
 
-	private Method makeStoryPathsMethodPublic(
-			Class<? extends ConfigurableEmbedder> testClass)
+	@SuppressWarnings("unchecked")
+    private static Method makeStoryPathsMethodPublic(Class<? extends ConfigurableEmbedder> clazz)
 			throws NoSuchMethodException {
-		Method method;
 		try {
-			method = testClass.getDeclaredMethod("storyPaths", (Class[]) null);
+			Method method = clazz.getDeclaredMethod("storyPaths", (Class[]) null);
+			method.setAccessible(true);
+			return method;
 		} catch (NoSuchMethodException e) {
-			method = testClass.getMethod("storyPaths", (Class[]) null);
+			Class<?> superclass = clazz.getSuperclass();
+			if (superclass != null && ConfigurableEmbedder.class.isAssignableFrom(superclass)) {
+				return makeStoryPathsMethodPublic((Class<? extends ConfigurableEmbedder>) superclass);
+			}
+			throw e;
 		}
-		method.setAccessible(true);
-		return method;
 	}
 
 	private List<CandidateSteps> getCandidateSteps() {

--- a/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitScenarioReporter.java
+++ b/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitScenarioReporter.java
@@ -90,7 +90,7 @@ public class JUnitScenarioReporter extends NullStoryReporter {
 			for (Description storyDescription : storyDescriptions) {
 				if (storyDescription.isSuite()
 						&& storyDescription.getDisplayName().equals(
-								story.getName())) {
+								JUnitStringDecorator.getJunitSafeString(story.getName()))) {
 					currentStoryDescription = storyDescription;
 					notifier.fireTestStarted(storyDescription);
 

--- a/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitStringDecorator.java
+++ b/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitStringDecorator.java
@@ -1,0 +1,20 @@
+package de.codecentric.jbehave.junit.monitoring;
+
+/**
+ * @author Valery_Yatsynovich
+ */
+public final class JUnitStringDecorator
+{
+	private JUnitStringDecorator()
+	{
+		// Utility class
+	}
+
+	public static String getJunitSafeString(String string) {
+		return replaceLinebreaks(string).replaceAll("[\\(\\)]", "|");
+	}
+
+	private static String replaceLinebreaks(String string) {
+		return string.replaceAll("\r", "\n").replaceAll("\n+", ", ");
+	}
+}

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitDescriptionGeneratorTest.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitDescriptionGeneratorTest.java
@@ -35,6 +35,7 @@ import org.jbehave.core.annotations.ScenarioType;
 import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.configuration.Keywords;
 import org.jbehave.core.embedder.PerformableTree;
+import org.jbehave.core.embedder.PerformableTree.ExamplePerformableScenario;
 import org.jbehave.core.embedder.PerformableTree.PerformableRoot;
 import org.jbehave.core.embedder.PerformableTree.PerformableScenario;
 import org.jbehave.core.embedder.PerformableTree.PerformableStory;
@@ -442,6 +443,18 @@ public class JUnitDescriptionGeneratorTest {
 	private void generateScenarioDescription() {
 		PerformableScenario performableScenario = mock(PerformableScenario.class);
 		when(performableScenario.getScenario()).thenReturn(scenario);
+		ExamplesTable examplesTable = scenario.getExamplesTable();
+		boolean hasExamples = examplesTable != null && examplesTable.getRowCount() > 0;
+		when(performableScenario.hasExamples()).thenReturn(hasExamples);
+		if (hasExamples) {
+			List<ExamplePerformableScenario> exampleScenarios = new ArrayList<>();
+			for (Map<String, String> row : examplesTable.getRows()) {
+				ExamplePerformableScenario exampleScenario = mock(ExamplePerformableScenario.class);
+				when(exampleScenario.getParameters()).thenReturn(row);
+				exampleScenarios.add(exampleScenario);
+			}
+			when(performableScenario.getExamples()).thenReturn(exampleScenarios);
+		}
 		description = generator.createDescriptionFrom(performableScenario);
 	}
 

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitScenarioReporterTest.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitScenarioReporterTest.java
@@ -48,17 +48,15 @@ public class JUnitScenarioReporterTest {
 	@Before
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
-		rootDescription = Description.createTestDescription(this.getClass(),
-				NAME_ROOT);
-		storyDescription = Description.createTestDescription(this.getClass(),
-				NAME_STORY);
+		rootDescription = Description.createSuiteDescription(NAME_ROOT);
+		storyDescription = Description.createSuiteDescription(NAME_STORY);
 		rootDescription.addChild(storyDescription);
 		scenarioDescription = Description.createTestDescription(
 				this.getClass(), NAME_SCENARIO);
 		storyDescription.addChild(scenarioDescription);
 
 		story = new Story();
-		story.namedAs("story(" + this.getClass().getName() + ")");
+		story.namedAs(NAME_STORY);
 		keywords = new Keywords();
 	}
 
@@ -356,19 +354,19 @@ public class JUnitScenarioReporterTest {
 	}
 
 	@Test
-    public void shouldNotifyAboutNotAllowedScenario() {
-	    Description child1 = addChildToScenario("child");
+	public void shouldNotifyAboutNotAllowedScenario() {
+		Description child1 = addChildToScenario("child");
 
-        reporter = new JUnitScenarioReporter(notifier, ONE_STEP,
-                rootDescription, keywords);
+		reporter = new JUnitScenarioReporter(notifier, ONE_STEP,
+				rootDescription, keywords);
 
-        reportStoryAndScenarioStart(reporter);
-        reporter.scenarioNotAllowed(Mockito.mock(Scenario.class), "filter");
-        verifyStoryStarted();
-        verifyScenarioStarted();
-        verify(notifier).fireTestIgnored(child1);
-        verify(notifier).fireTestIgnored(scenarioDescription);
-    }
+		reportStoryAndScenarioStart(reporter);
+		reporter.scenarioNotAllowed(Mockito.mock(Scenario.class), "filter");
+		verifyStoryStarted();
+		verifyScenarioStarted();
+		verify(notifier).fireTestIgnored(child1);
+		verify(notifier).fireTestIgnored(scenarioDescription);
+	}
 
 	private void reportScenarioAndStoryFinish(JUnitScenarioReporter reporter) {
 		reporter.afterScenario();

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitScenarioReporterTest.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitScenarioReporterTest.java
@@ -9,6 +9,7 @@ import org.jbehave.core.configuration.Keywords;
 import org.jbehave.core.failures.FailingUponPendingStep;
 import org.jbehave.core.failures.PendingStepStrategy;
 import org.jbehave.core.failures.UUIDExceptionWrapper;
+import org.jbehave.core.model.Scenario;
 import org.jbehave.core.model.Story;
 import org.junit.Before;
 import org.junit.Test;
@@ -303,7 +304,8 @@ public class JUnitScenarioReporterTest {
 
 	@Test
 	public void shouldFailForPendingStepsAtBothStepAndScenarioLevelsIfConfigurationSaysSo() {
-		Description child = addChildToScenario("child");
+		Description child1 = addChildToScenario("child1");
+		Description child2 = addChildToScenario("child2");
 
 		reporter = new JUnitScenarioReporter(notifier, ONE_STEP,
 				rootDescription, keywords);
@@ -312,14 +314,15 @@ public class JUnitScenarioReporterTest {
 		reporter.usePendingStepStrategy(strategy);
 
 		reportStoryAndScenarioStart(reporter);
-		reporter.pending("child");
-		reporter.failed("child",
+		reporter.pending("child1");
+		reporter.failed("child2",
 				new UUIDExceptionWrapper(new Exception("FAIL")));
 		verifyStoryStarted();
 		verifyScenarioStarted();
-		verify(notifier).fireTestStarted(child);
+		verify(notifier).fireTestStarted(child1);
 		verify(notifier, times(2)).fireTestFailure(Mockito.<Failure> anyObject());
-		verify(notifier, times(2)).fireTestFinished(child);
+		verify(notifier, times(1)).fireTestFinished(child1);
+		verify(notifier, times(1)).fireTestFinished(child2);
 	}
 
 	@Test
@@ -351,6 +354,21 @@ public class JUnitScenarioReporterTest {
 		verify(notifier).fireTestFailure(argument.capture());
 		assertThat(argument.getValue().getDescription(), is(storyDescription));
 	}
+
+	@Test
+    public void shouldNotifyAboutNotAllowedScenario() {
+	    Description child1 = addChildToScenario("child");
+
+        reporter = new JUnitScenarioReporter(notifier, ONE_STEP,
+                rootDescription, keywords);
+
+        reportStoryAndScenarioStart(reporter);
+        reporter.scenarioNotAllowed(Mockito.mock(Scenario.class), "filter");
+        verifyStoryStarted();
+        verifyScenarioStarted();
+        verify(notifier).fireTestIgnored(child1);
+        verify(notifier).fireTestIgnored(scenarioDescription);
+    }
 
 	private void reportScenarioAndStoryFinish(JUnitScenarioReporter reporter) {
 		reporter.afterScenario();
@@ -445,11 +463,9 @@ public class JUnitScenarioReporterTest {
 	}
 
 	private Description addChildToScenario(String childName) {
-
 		Description child = Description.createTestDescription(this.getClass(),
 				childName);
 		scenarioDescription.addChild(child);
 		return child;
 	}
-
 }

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitStringDecoratorTest.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitStringDecoratorTest.java
@@ -1,0 +1,22 @@
+package de.codecentric.jbehave.junit.monitoring;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Valery_Yatsynovich
+ */
+public class JUnitStringDecoratorTest
+{
+	@Test
+	public void shouldReplaceParenthesesWithVerticalBars() {
+		String actual = JUnitStringDecorator.getJunitSafeString("some string with (parentheses)");
+		Assert.assertEquals("some string with |parentheses|", actual);
+	}
+
+	@Test
+	public void shouldReplaceCrLfWithCommas() {
+		String actual = JUnitStringDecorator.getJunitSafeString("some\n\r string with \r\n\ncrlf\n\n");
+		Assert.assertEquals("some,  string with , crlf, ", actual);
+	}
+}

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/LoggerTest.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/LoggerTest.java
@@ -89,7 +89,7 @@ public class LoggerTest {
 	@Test
 	public void shouldHandleNonStringVars() {
 		setLevel("INFO");
-		List<Long> longs = new ArrayList<Long>();
+		List<Long> longs = new ArrayList<>();
 		longs.add(1L);
 		longs.add(2L);
 		longs.add(3L);

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/step/ExampleSteps.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/step/ExampleSteps.java
@@ -59,7 +59,7 @@ public class ExampleSteps {
 
 	@Given("the variables: $variables")
 	public void givenTheVariables(ExamplesTable table) {
-		variables = new HashMap<String, Integer>();
+		variables = new HashMap<>();
 		for (Map<String, String> row : table.getRows()) {
 			variables.put(row.get("name"), Integer.valueOf(row.get("value")));
 		}

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/suite/StoriesWithAllSortsOfBeforeAndAfter.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/suite/StoriesWithAllSortsOfBeforeAndAfter.java
@@ -40,8 +40,6 @@ public class StoriesWithAllSortsOfBeforeAndAfter extends JUnitStories {
 
 	public StoriesWithAllSortsOfBeforeAndAfter() {
 		System.setProperty(Logger.PROP_JJM_LOGLEVEL, "debug");
-		JUnitReportingRunner.recommendedControls(configuredEmbedder());
-
 		CrossReference crossReference = new CrossReference("dummy")
 				.withJsonOnly().withOutputAfterEachStory(true)
 				.excludingStoriesWithNoExecutedScenarios(true);
@@ -56,6 +54,7 @@ public class StoriesWithAllSortsOfBeforeAndAfter extends JUnitStories {
 								.withFormats(Format.XML, Format.HTML)
 								.withCrossReference(crossReference))
 				.useParameterControls(new ParameterControls("<", ">", true));
+		JUnitReportingRunner.recommendedControls(configuredEmbedder());
 	}
 
 	@Override


### PR DESCRIPTION
Not sure if you are interested in these changes, but I was needed them to handle properly failures in @Before / @After methods. Also I've made a breaking changes: upgraded to JBehave 4.0.3.
- Upgarding to 
  - JBehave 4.0.5
  - JUnit 4.12.
  - Mockito 1.10.19.
- Adding support for @BeforeStory/@AfterStory and @BeforeScenario/@AfterScenario
- Fix for issue #80 "JUnitScenarioReporter throws NPE when story file name contains parentheses"
- Filtered out stories and scenarios shouldn't be included in JUnit description tree
- Refactor and optimize creation of configuredEmbedder and candidateSteps
- Search for "storyPaths" method in superclasses > 
  "Previously "storyPaths" method was searched in all methods of the test
  class (with any visibility modifier) and in public methods of test class
  superclasses. Now all methods of superclasses are included in the search.
  It may be useful for cases when there is some common class with protected
  "storyPaths" method and there is a set of sub-classes adding custom logic,
  but not overriding "storyPaths" method."
- Use ExamplePerformableScenario to generate descritpions for examples >     ExamplePerformableScenario suits better for generation of descriptions for examples than ExamplesTable from scenario, since JBehave may apply additional operations which are reflected only in ExamplePerfoemableScenario
