### PR TITLE
added recursive lookup for storyPaths

### DIFF
--- a/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitReportingRunner.java
+++ b/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitReportingRunner.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.xml.crypto.NoSuchMechanismException;
+
 import org.jbehave.core.ConfigurableEmbedder;
 import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.embedder.Embedder;
@@ -135,7 +137,7 @@ public class JUnitReportingRunner extends BlockJUnit4ClassRunner {
 	@SuppressWarnings("unchecked")
 	private void getStoryPathsFromJUnitStories(
 			Class<? extends ConfigurableEmbedder> testClass)
-			throws NoSuchMethodException, IllegalAccessException,
+			throws NoSuchMethodException, IllegalAccessException ,
 			InvocationTargetException {
 		configuredEmbedder = configurableEmbedder.configuredEmbedder();
 		Method method = makeStoryPathsMethodPublic(testClass);
@@ -148,12 +150,26 @@ public class JUnitReportingRunner extends BlockJUnit4ClassRunner {
 			throws NoSuchMethodException {
 		Method method;
 		try {
-			method = testClass.getDeclaredMethod("storyPaths", (Class[]) null);
+			method = methodLookup(testClass, "storyPaths");
 		} catch (NoSuchMethodException e) {
 			method = testClass.getMethod("storyPaths", (Class[]) null);
 		}
 		method.setAccessible(true);
 		return method;
+	}
+
+	private Method methodLookup(Class<?> clazz, String methodName) throws NoSuchMethodException {
+		while (clazz != null) {
+			Method[] methods = clazz.getDeclaredMethods();
+			for (Method method : methods) {
+				// Test any other things about it beyond the name...
+				if (method.getName().equals(methodName)) {
+					return method;
+				}
+			}
+			clazz = clazz.getSuperclass();
+		}
+		throw new NoSuchMethodException("Can not find method: " + methodName);
 	}
 
 	private void getCandidateSteps() {

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/AbstractJUnitStories.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/AbstractJUnitStories.java
@@ -1,0 +1,45 @@
+package de.codecentric.jbehave.junit.monitoring;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jbehave.core.configuration.Configuration;
+import org.jbehave.core.configuration.MostUsefulConfiguration;
+import org.jbehave.core.junit.JUnitStories;
+import org.jbehave.core.reporters.StoryReporterBuilder;
+import org.jbehave.core.steps.InjectableStepsFactory;
+import org.jbehave.core.steps.InstanceStepsFactory;
+
+import de.codecentric.jbehave.junit.monitoring.JUnitReportingRunner;
+import de.codecentric.jbehave.junit.monitoring.step.ExampleSteps;
+
+/**
+ * Abstract {@link JUnitStories} implementation.
+ * 
+ * @author Michal Bocek
+ * @since 4/8/2016
+ */
+public class AbstractJUnitStories extends JUnitStories {
+
+	public AbstractJUnitStories() {
+		JUnitReportingRunner.recommendedControls(configuredEmbedder());
+	}
+
+	@Override
+	public Configuration configuration() {
+		return new MostUsefulConfiguration()
+				.useStoryReporterBuilder(new StoryReporterBuilder()
+						.withDefaultFormats());
+	}
+
+	@Override
+	public InjectableStepsFactory stepsFactory() {
+		return new InstanceStepsFactory(configuration(), new ExampleSteps());
+	}
+
+	@Override
+	protected List<String> storyPaths() {
+		return Arrays.asList("de/codecentric/jbehave/junit/monitoring/Multiplication.story");
+	}
+
+}

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/InheritedJUnitStories.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/InheritedJUnitStories.java
@@ -1,0 +1,13 @@
+package de.codecentric.jbehave.junit.monitoring;
+
+import org.jbehave.core.junit.JUnitStories;
+
+/**
+ * Abstract {@link JUnitStories} implementation.
+ * 
+ * @author Michal Bocek
+ * @since 4/8/2016
+ */
+public class InheritedJUnitStories extends AbstractJUnitStories {
+
+}

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/suite/JUnitReportingRunnerIntegrationTest.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/suite/JUnitReportingRunnerIntegrationTest.java
@@ -22,6 +22,7 @@ import org.mockito.MockitoAnnotations;
 import de.codecentric.jbehave.junit.monitoring.ExampleScenarioJUnitStories;
 import de.codecentric.jbehave.junit.monitoring.ExampleScenarioJUnitStoriesLocalized;
 import de.codecentric.jbehave.junit.monitoring.ExampleScenarioJUnitStory;
+import de.codecentric.jbehave.junit.monitoring.InheritedJUnitStories;
 import de.codecentric.jbehave.junit.monitoring.JUnitReportingRunner;
 
 @RunWith(Parameterized.class)
@@ -43,6 +44,10 @@ public class JUnitReportingRunnerIntegrationTest {
 	@Parameters
 	public static Collection<Object[]> data() {
 		Object[][] params = {
+				{ InheritedJUnitStories.class,
+						"Multiplication.story",
+						"Scenario: 2 squared",
+						"Given a variable x with value 2" },
 				{ ExampleScenarioJUnitStories.class,
 						"Multiplication.story",
 						"Scenario: 2 squared",


### PR DESCRIPTION
When your test hierarchy implements JUnitStories.storyPaths in super class runner will not find storyPaths method. This PR should fix this issue.
