### PR TITLE
Fix NullPointer in ExamplesTable Description

### DIFF
--- a/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitDescriptionGenerator.java
+++ b/src/main/java/de/codecentric/jbehave/junit/monitoring/JUnitDescriptionGenerator.java
@@ -167,7 +167,7 @@ public class JUnitDescriptionGenerator {
 		for (ExamplePerformableScenario examplePerformableScenario : performableScenario.getExamples()) {
 			Description exampleRowDescription = Description.createSuiteDescription(
 							configuration.keywords().examplesTableRow() + " " +
-									examplePerformableScenario.getParameters(), (Annotation[]) null);
+									examplePerformableScenario.getParameters());
 			scenarioDescription.addChild(exampleRowDescription);
 			if (hasGivenStories(scenario)) {
 				insertGivenStories(scenario, exampleRowDescription);

--- a/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitDescriptionGeneratorTest.java
+++ b/src/test/java/de/codecentric/jbehave/junit/monitoring/JUnitDescriptionGeneratorTest.java
@@ -1,13 +1,7 @@
 package de.codecentric.jbehave.junit.monitoring;
 
 import static org.hamcrest.CoreMatchers.everyItem;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyInt;
@@ -292,6 +286,8 @@ public class JUnitDescriptionGeneratorTest {
 							startsWith("Given Step1"))));
 			assertThat(exampleDescription,
 					hasProperty("displayName", startsWith("Example: " + row)));
+			// Test is for verifying that the getAnnotations() is successfully executed
+			assertThat(exampleDescription.getAnnotations(), is(not(nullValue())));
 		}
 	}
 


### PR DESCRIPTION
Invalid parameter for Description has caused NullPointer when the annotations where requested via getAnnotations() or getAnnotation(clazz)