### PR TITLE
Upgrade to maven-javadoc-plugin 3.0.0-M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.4</version>
+				<version>3.0.0-M1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>


### PR DESCRIPTION
maven-javadoc-plugin 3.0.0-M1 contains important fixes (https://issues.apache.org/jira/browse/MJAVADOC-488) that will allow to build the project on Java 9 successfully