### PR TITLE
Fixed null pointer issue that causes mvn test to fail with NullPointer

### DIFF
--- a/src/main/java/com/github/valfirst/jbehave/junit/monitoring/JUnitScenarioReporter.java
+++ b/src/main/java/com/github/valfirst/jbehave/junit/monitoring/JUnitScenarioReporter.java
@@ -253,7 +253,7 @@ public class JUnitScenarioReporter extends NullStoryReporter {
 	@Override
 	public void beforeStep(String title) {
 		TestState testState = this.testState.get();
-		if (!testState.isGivenStoryRunning()) {
+		if (!testState.isGivenStoryRunning() && testState.currentStep != null) {
 			notifier.fireTestStarted(testState.currentStep);
 		}
 	}


### PR DESCRIPTION
We're using `valfirst/jbehave-junit-runner` to run JUnitStories classes from Maven Surefire via `mvn test`. This works fine, except for this minute bug, that causes JUnit's ForkBooter to fail with a NullPointerException. Suggest to pull it.