### PR TITLE
Fix behaviour if examples are used with composite steps

### DIFF
--- a/src/main/java/com/github/valfirst/jbehave/junit/monitoring/JUnitScenarioReporter.java
+++ b/src/main/java/com/github/valfirst/jbehave/junit/monitoring/JUnitScenarioReporter.java
@@ -160,6 +160,12 @@ public class JUnitScenarioReporter extends NullStoryReporter {
 		return Collections.emptyList();
 	}
 
+	private Collection<Description> getAllDescendants(Description step) {
+		List<Description> descendants = new ArrayList<>();
+		descendants.addAll(getAllDescendants(step.getChildren()));
+		return descendants;
+	}
+
 	private Collection<Description> getAllDescendants(List<Description> steps) {
 		List<Description> descendants = new ArrayList<>();
 		for (Description child : steps) {
@@ -244,7 +250,7 @@ public class JUnitScenarioReporter extends NullStoryReporter {
 				processAfterScenario();
 			}
 			testState.moveToNextExample();
-			testState.stepDescriptions = testState.currentExample.getChildren().iterator();
+			testState.stepDescriptions = getAllDescendants(testState.currentExample).iterator();
 			testState.moveToNextStep();
 			processBeforeScenario();
 		}

--- a/src/test/java/com/github/valfirst/jbehave/junit/monitoring/JUnitScenarioReporterTest.java
+++ b/src/test/java/com/github/valfirst/jbehave/junit/monitoring/JUnitScenarioReporterTest.java
@@ -282,6 +282,47 @@ public class JUnitScenarioReporterTest {
 	}
 
 	@Test
+	public void shouldHandleExampleStepsInCombinationWithCompositeSteps() {
+		// one story, one scenario, one example, one composite step of 2 steps
+		Description example = addChildToScenario(keywords.examplesTableRow() + " "
+				+ "row");
+		Description step = Description.createTestDescription(this.getClass(),
+				"Step");
+		example.addChild(step);
+
+		Description comp1 = Description.createTestDescription(this.getClass(),
+				"comp1");
+		step.addChild(comp1);
+		Description comp2 = Description.createTestDescription(this.getClass(),
+				"comp2");
+		step.addChild(comp2);
+
+		reporter = new JUnitScenarioReporter(notifier, TWO_COMPOSITE_STEPS,
+				rootDescription, keywords);
+
+		reportStoryAndScenarioStart(reporter);
+		reporter.example(null);
+		reporter.beforeStep("child");
+		reporter.successful("child");
+		reporter.beforeStep("comp1");
+		reporter.successful("comp1");
+		reporter.beforeStep("comp2");
+		reporter.successful("comp2");
+		reportStepSuccess(reporter);
+		reportScenarioAndStoryFinish(reporter);
+
+		verifyTestRunStarted();
+		verifyStoryStarted();
+		verifyScenarioStarted();
+		verifyTestStart();
+		verify(notifier).fireTestStarted(step);
+		verifyStepSuccess(comp1);
+		verifyStepSuccess(comp2);
+		verify(notifier).fireTestFinished(step);
+		verifyTestFinish();
+	}
+
+	@Test
 	public void shouldHandleExampleStepsInCombinationWithGivenStories() {
 		// one story, one scenario, one given story, one example, one step
 		Description givenStoryDescription = addChildGivenStoryToScenario();


### PR DESCRIPTION
We use plenty of scenarios with Example tables and composite steps and bad enumeration of children for examples caused strange NPE in some jUnit4 classes, which then failed the mvn build.