### PR TITLE
Disable sonar analysis for external PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,13 @@ jobs:
       script:
         - sudo apt-get install jq
         - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
-        - mvn test jacoco:report coveralls:report sonar:sonar
+        - mvn test jacoco:report coveralls:report
         - java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r target/site/jacoco/jacoco.xml
+        - if [[ -n "${TRAVIS_PULL_REQUEST_SLUG}" && "${TRAVIS_PULL_REQUEST_SLUG}" != "${TRAVIS_REPO_SLUG}" ]]; then
+            echo "The pull request from ${TRAVIS_PULL_REQUEST_SLUG} is an EXTERNAL pull request. Skip sonar analysis.";
+          else
+            mvn sonar:sonar;
+          fi
 
 cache:
   directories:


### PR DESCRIPTION
Currently, travis-ci sonarclould addon cannot support external PRs.
If you do sonar analysis for all builds, the external PR build will
run sonar analysis without sonarcloud addon. And it will conduct:

```
    [ERROR] SonarQube server [https://localhost:9000] can not be reached
```
Make this quick fix to disable sonar analysis for external PRs.

Known related issue: travis-ci/travis-ci#8379