### PR TITLE
[CI] Run Sonar scan on Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jdk:
 jobs:
   include:
     - stage: Sonar check and code coverage reporting
-      jdk: oraclejdk8
+      jdk: openjdk11
       addons:
         sonarcloud:
           organization: "valfirst-github"

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,13 @@
 						<groupId>org.eluder.coveralls</groupId>
 						<artifactId>coveralls-maven-plugin</artifactId>
 						<version>4.3.0</version>
+						<dependencies>
+							<dependency>
+								<groupId>javax.xml.bind</groupId>
+								<artifactId>jaxb-api</artifactId>
+								<version>2.2.3</version>
+							</dependency>
+						</dependencies>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
Official notification from SonarCloud team:

"Hello,

The version of Java installed in your scanner environment must be upgraded to at least Java 11! We are ending support for older Java versions soon. You will still be able to use SonarCloud for your Java 8 projects, this change only affects the execution of our scanner, not the code your project is written in.

Here is how the deprecation will happen:

- Between the 11th and the 15th of January, you will experience a brownout where only the first scan of every project with an older version of Java will fail.
 - After the 1st of February 2021, all analysis with Java <11 in your scanner environment will fail unless you upgrade to a supported version.

Please upgrade these projects now:

JBehave JUnit Runner (Valery Yatsynovich)
If you have any questions, please ask them on this dedicated thread in the Community forum (https://community.sonarsource.com/).

How to upgrade: https://sonarcloud.io/documentation/appendices/move-analysis-java-11/
The SonarCloud team."