### PR TITLE
[CI] Update coordinates of SonarQube maven plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           if [[ -n $GITHUB_TOKEN && -n $SONAR_TOKEN ]]; then
-            mvn sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=valfirst-github -Dsonar.projectKey=com.github.valfirst:jbehave-junit-runner -Dsonar.token=${SONAR_TOKEN}  -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.pullrequest.key=${{github.event.pull_request.number}};
+            mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=valfirst-github -Dsonar.projectKey=com.github.valfirst:jbehave-junit-runner -Dsonar.token=${SONAR_TOKEN}  -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.pullrequest.key=${{github.event.pull_request.number}};
           else
             echo No GITHUB_TOKEN and/or SONAR_TOKEN, the publishing to SonarCloud is skipped;
           fi;


### PR DESCRIPTION
The fixed warning is:

> Warning:  The artifact org.codehaus.mojo:sonar-maven-plugin:jar:4.0.0.4121 has been relocated to org.sonarsource.scanner.maven:sonar-maven-plugin:jar:4.0.0.4121: SonarQube plugin was moved to SonarSource organisation